### PR TITLE
remove the "use bincode", and allow to specify

### DIFF
--- a/.github/workflows/run-on-push.yml
+++ b/.github/workflows/run-on-push.yml
@@ -45,10 +45,18 @@ jobs:
         sudo apt-get install -y build-essential clang-12
     - name: Create a test package using vpp-api-gen
       run: |
-        cargo run -- --in-file /usr/share/vpp/api/ --parse-type Tree --create-package --package-name testvpp
+        pwd
+        ls -al ..
+        cargo run -- --in-file /usr/share/vpp/api/ --parse-type Tree --create-package --package-name testvpp --vppapi-opts '{ path = "../vpp-api/{crate}/" }'
+        echo "Finished creating the test package"
     - name: Run tests within the generated package
       run: |
         cd ../testvpp
+        echo '==== Cargo.toml ===='
+        cat Cargo.toml
+        echo '==== end ===='
+        pwd
+
         cargo test -- --test-threads 1
 
 

--- a/vpp-api-gen/src/bin/api-gen/code_gen.rs
+++ b/vpp-api-gen/src/bin/api-gen/code_gen.rs
@@ -70,7 +70,11 @@ pub fn gen_code(
     println!("Generated {}.rs", fileName.trim_start_matches("/"));
 }
 
-pub fn create_cargo_toml(package_path: &str, packageName: &str) {
+fn vpp_api_crate(name: &str, vppapi_opts: &str) -> String {
+    format!("{} = {}\n", name, &vppapi_opts.replace("{crate}", name))
+}
+
+pub fn create_cargo_toml(package_path: &str, packageName: &str, vppapi_opts: &str) {
     println!("Generating Cargo file");
     let mut code = String::new();
     code.push_str("[package] \n");
@@ -81,9 +85,7 @@ pub fn create_cargo_toml(package_path: &str, packageName: &str) {
 
     code.push_str("[dev-dependencies] \n");
     code.push_str("trybuild = {version = \"1.0\", features = [\"diff\"]} \n\n");
-    code.push_str(
-        "vpp-api-transport = { git=\"https://github.com/ayourtch/vpp-api\", branch=\"main\" } \n",
-    );
+    code.push_str(&vpp_api_crate("vpp-api-transport", &vppapi_opts));
 
     code.push_str("[dependencies] \n");
     code.push_str("serde = { version = \"1.0\", features = [\"derive\"] } \n");
@@ -99,20 +101,14 @@ pub fn create_cargo_toml(package_path: &str, packageName: &str) {
     code.push_str("typenum = \"*\" \n");
     code.push_str("bincode = \"1.2.1\" \n");
     code.push_str("serde_yaml = \"0.8\" \n");
-    code.push_str(
-        "vpp-api-encoding = {git=\"https://github.com/ayourtch/vpp-api\", branch=\"main\" } \n",
-    );
-    code.push_str(
-        "vpp-api-message = {git=\"https://github.com/ayourtch/vpp-api\", branch=\"main\" } \n",
-    );
+    code.push_str(&vpp_api_crate("vpp-api-encoding", &vppapi_opts));
+    code.push_str(&vpp_api_crate("vpp-api-message", &vppapi_opts));
     code.push_str("lazy_static = \"1.4.0\" \n");
     code.push_str("regex = \"1\" \n");
     code.push_str("syn ={ version= \"1.0\", features=[\"extra-traits\",\"full\"]} \n");
     code.push_str("quote = \"1.0\" \n");
     code.push_str("proc-macro2 = \"1.0.26\" \n");
-    code.push_str(
-        "vpp-api-macros = {git=\"https://github.com/ayourtch/vpp-api\", branch=\"main\"} \n",
-    );
+    code.push_str(&vpp_api_crate("vpp-api-macros", &vppapi_opts));
 
     let mut file = File::create(format!("{}/{}/Cargo.toml", package_path, packageName)).unwrap();
     file.write_all(code.as_bytes()).unwrap();

--- a/vpp-api-gen/src/bin/api-gen/main.rs
+++ b/vpp-api-gen/src/bin/api-gen/main.rs
@@ -69,6 +69,13 @@ pub struct Opts {
     #[clap(long, default_value = "someVPP")]
     pub package_name: String,
 
+    /// Options to specify within generated Cargo.toml for all crates from vpp-api
+    #[clap(
+        long,
+        default_value = "{ git=\"https://github.com/ayourtch/vpp-api\", branch=\"main\" }"
+    )]
+    pub vppapi_opts: String,
+
     /// Package name for the generated package
     #[clap(long, default_value = "../")]
     pub package_path: String,
@@ -271,7 +278,7 @@ fn main() {
                     ))
                     .expect("Error creating package/examples dir");
                     generate_lib_file(&opts.package_path, &api_files, &opts.package_name);
-                    create_cargo_toml(&opts.package_path, &opts.package_name);
+                    create_cargo_toml(&opts.package_path, &opts.package_name, &opts.vppapi_opts);
                     let crate_dir = env!("CARGO_MANIFEST_DIR");
                     eprintln!("package path: {}", &crate_dir);
                     copy_file_with_fixup(

--- a/vpp-api-macros/src/lib.rs
+++ b/vpp-api-macros/src/lib.rs
@@ -170,7 +170,7 @@ pub fn derive_unionident(input: proc_macro::TokenStream) -> proc_macro::TokenStr
         }
     });
     let expanded = quote! {
-        use bincode;
+        // use bincode;
         impl #name{
             fn new() -> #name {
                 let mut out: FixedSizeArray<u8, typenum::#ty> = Default::default();


### PR DESCRIPTION
the vpp-api packages option within the generated code.

Use this to test the generated code with the vpp-api
being submitted, rather than the existing version
from github.